### PR TITLE
Add `verbose` flag

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -147,6 +147,28 @@ If the command is interactive, you can send it input as well.::
     a good option.
 
 
+Failing Fast
+------------
+
+You can have non-zero exit codes propigate as exceptions::
+
+    >>> from shell import shell
+    >>> shell('ls /not/a/real/place', die=True)
+	Traceback (most recent call last):
+        ...
+	shell.CommandError: Command exited with code 1
+    >>> import sys
+    >>> from shell import CommandError
+    >>> try:
+    >>>     shell('ls /also/definitely/fake', die=True)
+    >>> except CommandError, e:
+    >>>     print e.stderr
+    >>>     sys.exit(e.code)
+    ls: /also/definitely/fake: No such file or directory
+    $ echo $?
+    1
+
+
 Chaining
 --------
 

--- a/shell.py
+++ b/shell.py
@@ -44,7 +44,11 @@ class MissingCommandException(ShellException):
 
 class CommandError(ShellException):
     """Thrown when a command fails."""
-    pass
+    def __init__(self, message, code, stderr):
+        self.message = message
+        self.code = code
+        self.stderr = stderr
+        super(CommandError, self).__init__(message)
 
 
 class Shell(object):
@@ -132,8 +136,10 @@ class Shell(object):
             self.code = self._popen.returncode
 
         if self.die and self.code != 0:
-            raise CommandError('Command exited with code {}'.format(self.code))
-
+            raise CommandError(
+                message='Command exited with code {}'.format(self.code),
+                code=self.code,
+                stderr=stderr)
 
     def run(self, command):
         """

--- a/shell.py
+++ b/shell.py
@@ -25,6 +25,7 @@ If you need to extend the behavior, you can also use the ``Shell`` object::
 """
 import shlex
 import subprocess
+import sys
 
 
 __author__ = 'Daniel Lindsley'
@@ -74,14 +75,19 @@ class Shell(object):
     Optionally accepts a ``strip_empty`` parameter, which should be a boolean.
     If set to ``True``, only non-empty lines from ``Shell.output`` or
     ``Shell.errors`` will be returned. (Default: ``True``)
+
+    Optionally accepts a ``verbose`` parameter, which should be a boolean.
+    If set to ``True``, prints stdout to stdout and stderr to stderr as
+    execution happens. (Default: ``False``)
     """
     def __init__(self, die=False, has_input=False, record_output=True,
-                 record_errors=True, strip_empty=True):
+                 record_errors=True, strip_empty=True, verbose=False):
         self.die = die
         self.has_input = has_input
         self.record_output = record_output
         self.record_errors = record_errors
         self.strip_empty = strip_empty
+        self.verbose = verbose
 
         self.last_command = ''
         self.line_breaks = '\n'
@@ -114,13 +120,19 @@ class Shell(object):
 
         Records nothing if the ``record_*`` options have been set to ``False``.
         """
-        if self.record_output:
-            if stdout != None:
+        if stdout != None:
+            if self.record_output:
                 self._stdout += stdout
+            if self.verbose:
+                sys.stdout.write(stdout)
+                sys.stdout.flush()
 
-        if self.record_errors:
-            if stderr != None:
+        if stderr != None:
+            if self.record_errors:
                 self._stderr += stderr
+            if self.verbose:
+                sys.stderr.write(stderr)
+                sys.stderr.flush()
 
     def _communicate(self, the_input=None):
         """
@@ -292,7 +304,7 @@ class Shell(object):
 
 
 def shell(command, die=False, has_input=False, record_output=True,
-          record_errors=True, strip_empty=True):
+          record_errors=True, strip_empty=True, verbose=False):
     """
     A convenient shortcut for running commands.
 
@@ -320,6 +332,10 @@ def shell(command, die=False, has_input=False, record_output=True,
     If set to ``True``, only non-empty lines from ``Shell.output`` or
     ``Shell.errors`` will be returned. (Default: ``True``)
 
+    Optionally accepts a ``verbose`` parameter, which should be a boolean.
+    If set to ``True``, prints stdout to stdout and stderr to stderr as
+    execution happens. (Default: ``False``)
+
     Returns the ``Shell`` instance, which has been run with the given command.
 
     Example::
@@ -335,6 +351,7 @@ def shell(command, die=False, has_input=False, record_output=True,
         has_input=has_input,
         record_output=record_output,
         record_errors=record_errors,
-        strip_empty=strip_empty
+        strip_empty=strip_empty,
+        verbose=verbose
     )
     return sh.run(command)

--- a/tests.py
+++ b/tests.py
@@ -8,7 +8,7 @@ try:
 except ImportError:
     import unittest
 
-from shell import Shell, shell
+from shell import CommandError, Shell, shell
 
 
 class ShellTestCase(unittest.TestCase):
@@ -141,3 +141,9 @@ class ShellTestCase(unittest.TestCase):
 
         output = shell('cat -u', has_input=True).write('Hello, world!').output()
         self.assertEqual(output, ['Hello, world!'])
+
+    def test_die(self):
+        sh = Shell(die=True)
+        with self.assertRaises(CommandError):
+            sh.run('ls /maybe/this/exists/on/windows/or/something/idk')
+

--- a/tests.py
+++ b/tests.py
@@ -153,3 +153,13 @@ class ShellTestCase(unittest.TestCase):
             self.assertEqual(e.code, 1)
             self.assertEqual(e.stderr, no_die.errors()[0] + os.linesep)
 
+    def test_verbose(self):
+        sh = Shell(verbose=True)
+        with mock.patch('shell.sys.stdout') as mock_stdout:
+            sh.run('ls')
+            mock_stdout.write.assert_called_once_with(os.linesep.join(sh.output()) + os.linesep)
+        with mock.patch('shell.sys.stderr') as mock_stderr:
+            sh.run('ls /total/garbage/not/real/stuff')
+            mock_stderr.write.assert_called_once_with(os.linesep.join(sh.errors()) + os.linesep)
+
+

--- a/tests.py
+++ b/tests.py
@@ -146,4 +146,10 @@ class ShellTestCase(unittest.TestCase):
         sh = Shell(die=True)
         with self.assertRaises(CommandError):
             sh.run('ls /maybe/this/exists/on/windows/or/something/idk')
+        try:
+            no_die = shell('ls /other/fake/stuff/for/sure')  # get the stderr
+            sh.run('ls /other/fake/stuff/for/sure')
+        except CommandError, e:
+            self.assertEqual(e.code, 1)
+            self.assertEqual(e.stderr, no_die.errors()[0] + os.linesep)
 


### PR DESCRIPTION
To make shell calls a little more shelly. Built on top of the `die` flag branch, but independent of it.