### PR TITLE
Update to python3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ function::
     >>> from shell import shell
     >>> ls = shell('ls')
     >>> for file in ls.output():
-    ...     print file
+    ...     print(file)
     'another.txt'
 
 If you need to extend the behavior, you can also use the ``Shell`` object::

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ shell
 Built because every time I go to use `subprocess`_, I spend more time in the
 docs & futzing around than actually implementing what I'm trying to get done.
 
-.. _`subprocess`: http://docs.python.org/2.7/library/subprocess.html
+.. _`subprocess`: http://docs.python.org/3/library/subprocess.html
 
 Full docs are at https://shell.readthedocs.org/en/latest/.
 


### PR DESCRIPTION
`print`with parenthesis is compatible for python 2 and 3.
As python2 is EOL now, it's better to show example with `print()`.